### PR TITLE
grml-chroot: support efivarfs in EFI environments

### DIFF
--- a/usr_sbin/grml-chroot
+++ b/usr_sbin/grml-chroot
@@ -98,6 +98,9 @@ else
     mountit "sysfs" "sys"
     mountit "/dev"   "dev"   "--bind"
     mountit "devpts" "dev/pts"
+    if [ -d /sys/firmware/efi/efivars ] ; then
+      mountit "efivarfs" "sys/firmware/efi/efivars"
+    fi
     if [ -d "$DEST_"/run/udev ] && [ -d /run/udev ] ; then
       mountit "/run/udev" "/run/udev" "--bind"
     fi


### PR DESCRIPTION
CONFIG_EFI_VARS is no longer available since Debian kernel's git commit
20146398c4, and therefore efivars (the older interface handled from
within /sys) is gone with the kernel version shipped as of
Debian/bullseye (kernel >=5.10).  Only the newer efivarfs interface is
supported, this requires explicit mounting of /sys/firmware/efi/efivars
though.

Therefore, whenever /sys/firmware/efi/efivars is available, we are
running in EFI mode and might need EFI support also in the chroot.
Accordingly mount it then.

This is related to the corresponding change in grml-debootstrap:
https://github.com/grml/grml-debootstrap/pull/174