### PR TITLE
Set SHELL variable in run-welcome + run-screen

### DIFF
--- a/usr_share/run-screen
+++ b/usr_share/run-screen
@@ -6,6 +6,7 @@
 # License:       This file is licensed under the GPL v2.
 ################################################################################
 
+export SHELL=/bin/zsh
 # try to mitigate raceconditions from screen
 SCREENDIR_="/var/run/screen"
 mkdir -m 700 "${SCREENDIR_}/S-$USER" >/dev/null 2>&1
@@ -13,11 +14,11 @@ mkdir -m 700 "${SCREENDIR_}/S-$USER" >/dev/null 2>&1
 # now run screen with config
 
   if [ "$(id -u)" = 0 ] ; then
-    exec screen -U -c /etc/grml/screenrc
+    exec screen -U -c /etc/grml/screenrc -s "-$SHELL"
   elif [ -r "$HOME/.screenrc" ] ; then
-    exec screen -U -c "$HOME/.screenrc"
+    exec screen -U -c "$HOME/.screenrc" -s "-$SHELL"
   else
-    exec screen -U -c /etc/grml/screenrc_generic
+    exec screen -U -c /etc/grml/screenrc_generic -s "-$SHELL"
   fi
 
 ## END OF FILE #################################################################

--- a/usr_share/run-welcome
+++ b/usr_share/run-welcome
@@ -9,6 +9,8 @@
 # shellcheck disable=SC1091
 . /etc/grml/sh-lib
 
+export SHELL=/bin/zsh
+
 [ -r /etc/grml_version ] && GRMLVERSION=$(cat /etc/grml_version) || GRMLVERSION='(no version information available)'
 PATH=$HOME/bin:/bin:/sbin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/usr/games:/home/grml/bin
 CMDLINE=$(cat /proc/cmdline)
@@ -82,6 +84,6 @@ Happy hacking!               http://grml.org/
 "
 fi
 
-exec /bin/zsh -l
+exec "$SHELL" -l
 
 ## END OF FILE #################################################################


### PR DESCRIPTION
By default login(1) is called by agetty(8) and sets the SHELL variable "according to the appropriate fields in the password entry".

Our tty1 calls run-welcome, tty2 - tty4 call run-screen and tty5 - tty7 call agetty (with autologin grml). So, our tty1 - tty4 bypass agetty(8) + login(1) and (should) end in a the zsh shell (via the welcome-screen or GNU/screen) without the SHELL variable set.

run-welcome is designed to be started (only) on tty(1) and starts zsh anyway. But as we bypass login(1) the SHELL variable is not set. The same is true for run-screen, but instead of starting the zsh as login-shell, `screen` is called and runs the shell defined by the SHELL variable or /bin/sh if not defined.

So, we ended up using the systemd "Environment"-option to set the SHELL variable (grml/grml-live@6871972 + grml/grml-live@7422d31). Although this is a working solution, setting the SHELL variable in run-welcome
+ run-screen makes it more transparent, that the script is actually responsible to set the SHELL variable.

While debugging this problem, also noticed that screen should start the shell as login-shell (like all other ttys). To do so the given shell command needs to be prefixed with the '-' character.

grml/grml-live@6871972 + grml/grml-live@7422d31 can/should be reverted after this change has been applied.

Issues: grml/grml#135 + grml/grml#14