### PR TITLE
grml-resolution: Quick 'n dirty xrandr output parser fix

### DIFF
--- a/usr_bin/grml-resolution
+++ b/usr_bin/grml-resolution
@@ -23,11 +23,10 @@ COUNTER=0
 STRING=""
 
 # current mode
-CURRENT_NUM=$(xrandr | awk '/\*/ {print $1}' | tr -d '*')
-CURRENT_RESOLUTION=$(xrandr | awk '/\*/ {print $2 $3 $4}')
+CURRENT_RESOLUTION=$(xrandr | awk '/\*/ {print $1"_"$2}')
 
 # menu
-for i in $(xrandr | awk '{print $2$3$4}' | grep "^[0-9]") ; do
+for i in $(xrandr | awk '{print $1"_"$2}' | grep "^[0-9]") ; do
   STRING="$STRING $COUNTER $i"
   ((COUNTER++))
 done
@@ -43,9 +42,7 @@ esac
 
 CHOSE=$(cat "$RESOLUTION")
 
-if [ "$CHOSE" = "$CURRENT_NUM" ] ; then
-   dialog --title "$PN" --msgbox "Chosen resolution corresponds to current resolution. No changes needed." 0 0
-elif [ -n "$CHOSE" ] ; then
+if [ -n "$CHOSE" ] ; then
 # shellcheck disable=SC2015
   xrandr -s "$CHOSE" 2>"$ERROR" && \
   dialog --title "$PN" --msgbox "Running xrandr with resolution was succesful." 0 0 || \


### PR DESCRIPTION
The xrandr output parser of grml-resolution seems to be broken since at least Grml 2014.11: grml-resolution does not list possible resolutions but its corresponding refresh rates.

It seems like once upon a time xrandr had a 'size-index' in front of each resolution. This is not the case anymore and there does not seem to be an option to add that behaviour back to xrandr. So, CURRENT_NUM did not receive the 'size-index' of the current resolution, therefor I dropped that variable which was used to detect if the user had chosen the current resolution (nothing bad happens if xrandr sets the current resolution).

We now list the possible resolutions and refresh rates, separated by an underscore because `dialog` does not like spaces.
xrandr -s works fine with the chosen 'index' from dialog.

Closes: grml/grml-scripts#14