### PR TITLE
Add Depends: beep for run-welcome

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Rules-Requires-Root: no
 Package: grml-scripts
 Architecture: all
 Depends:
+ beep,
  dash,
  dialog,
  grml-etc-core,


### PR DESCRIPTION
The run-welcome script calls beep. Thus this package really should depend on it, and not rely on other packages bringing beep along with them.