### PR TITLE
Remove leftover symlink

### DIFF
--- a/usr_sbin/grml-config
+++ b/usr_sbin/grml-config
@@ -1,1 +1,0 @@
-grml-config-root


### PR DESCRIPTION
Oversight in e0faab3d087a3ad1b683311a5e6e4e1727173a56