### PR TITLE
grml-info: simplify browser selection

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Architecture: all
 Depends:
  dialog,
  grml-etc-core,
- links | w3m | links2,
+ links,
  perl,
  screen,
  zsh,

--- a/usr_bin/grml-info
+++ b/usr_bin/grml-info
@@ -21,19 +21,15 @@ fi
 
 # do we have X?
 if [ -n "$DISPLAY" ] && check4progs x-www-browser &>/dev/null ; then
-  exec x-www-browser $PAGE
-else
+  exec x-www-browser "$PAGE"
+elif check4progs links &>/dev/null ; then
   # no X: (or no x-www-browser)
-  if check4progs links2 &>/dev/null ; then
-    links2 $PAGE
-  elif check4progs w3m &>/dev/null; then
-    w3m $PAGE
-  elif check4progs links &>/dev/null ; then
-    links $PAGE
-  else
-    echo "Sorry, neither links2 nor w3m nor links available. Exiting.">&2
-    exit 1
-  fi
+  exec links "$PAGE"
+elif check4progs www-browser &>/dev/null ; then
+  exec www-browser "$PAGE"
 fi
+
+echo "Sorry, no browser available. Exiting.">&2
+exit 1
 
 ## END OF FILE #################################################################


### PR DESCRIPTION
Order becomes:

- in X11, try x-www-browser
- then links (which is links2 without X11 support)
- then www-browser

Drop w3m, which is IMO nowadays mostly useless. Also drop links2, as it provides no benefit over links2 on text consoles.

Closes: https://github.com/grml/grml-scripts/issues/37
